### PR TITLE
Add COPY TO PARTITION BY details

### DIFF
--- a/docs/extensions/httpfs.md
+++ b/docs/extensions/httpfs.md
@@ -180,6 +180,24 @@ works for both CSV and Parquet:
 COPY table_name TO 's3://bucket/file.extension';
 ```
 
+Partioned copy to S3 also works:
+
+```sql
+COPY table TO 's3://my-bucket/partitioned' (FORMAT PARQUET, PARTITION_BY (part_col_a, part_col_b));
+```
+
+An automatic check is performed for existing files/directories, which is currently quite conservative (and on S3 will add a bit of latency). To disable this check and force writing, an `ALLOW_OVERWRITE` flag is added:
+
+```sql
+COPY table TO 's3://my-bucket/partitioned' (FORMAT PARQUET, PARTITION_BY (part_col_a, part_col_b), ALLOW_OVERWRITE TRUE);
+```
+
+The naming scheme of the written files looks like this:
+
+```text
+s3://my-bucket/partitioned/part_col_a=<val>/part_col_b=<val>/data_<thread_number>.parquet
+```
+
 ### Configuration
 
 Some additional configuration options exist for the S3 upload, though the default values should suffice for most use cases.


### PR DESCRIPTION
This PR add the new COPY TO PARTITION BY syntax to the docs, according to the original description in the PR (https://github.com/duckdb/duckdb/pull/5964#issue-1552796444).